### PR TITLE
Speed

### DIFF
--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/CaptureFragment.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/CaptureFragment.java
@@ -61,7 +61,7 @@ public class CaptureFragment extends Fragment {
 
         mCameraView.addCameraListener(new CameraListener() {
             @Override
-            public void onPictureTaken(final byte[] picture) {
+            public void onPictureTaken(byte[] picture) {
                 // CameraUtils will generate image, with correct EXIF orientation, in a worker thread.
 
                 CameraUtils.decodeBitmap(picture, new CameraUtils.BitmapCallback() {
@@ -94,7 +94,6 @@ public class CaptureFragment extends Fragment {
         });
         return view;
     }
-
 
     private void errorAndExit(String message) {
         getActivity().finish();

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/IdentifyFragment.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/IdentifyFragment.java
@@ -7,6 +7,7 @@ import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -42,6 +43,7 @@ public class IdentifyFragment extends Fragment implements OnBeePartSelectedListe
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.identify_fragment, container, false);
 
+        Log.d(TAG, "Identify Fragment created");
         // Launch popup to explain to user how to identify bee parts
         BeeAlertDialog dialog = new BeeAlertDialog();
         dialog.setTargetFragment(this, 1);
@@ -78,7 +80,7 @@ public class IdentifyFragment extends Fragment implements OnBeePartSelectedListe
         });
 
         Submission submission = ((SubmissionInterface) getActivity()).getSubmission();
-        Bitmap bitmap = BitmapFactory.decodeFile(submission.getImageFilePath());
+        Bitmap bitmap = submission.getBitmap();
         int scaledWidth = container.getWidth();
         int scaledHeight = (int)(((double)bitmap.getHeight() / (double)bitmap.getWidth()) * container.getWidth());
         Bitmap scaled = Bitmap.createScaledBitmap(bitmap, scaledWidth, scaledHeight, false);

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/IdentifyFragment.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/IdentifyFragment.java
@@ -43,7 +43,6 @@ public class IdentifyFragment extends Fragment implements OnBeePartSelectedListe
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.identify_fragment, container, false);
 
-        Log.d(TAG, "Identify Fragment created");
         // Launch popup to explain to user how to identify bee parts
         BeeAlertDialog dialog = new BeeAlertDialog();
         dialog.setTargetFragment(this, 1);

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/Model/StorageAccessor.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/Model/StorageAccessor.java
@@ -32,7 +32,7 @@ public class StorageAccessor {
     private static final String FACTS_FILENAME = "facts";
     private static final String STATIC_FACTS_FILENAME = "facts";
     private static final String TEMPORARY_IMAGE_FILENAME = "TemporaryImageFile";
-    private static final int MEDIA_TYPE_IMAGE = 1;
+    public static final int MEDIA_TYPE_IMAGE = 1;
 
     public static void storeSubmission(Context context, Submission submission) throws IOException {
         Gson gson = new Gson();
@@ -104,8 +104,7 @@ public class StorageAccessor {
         return loadFacts(fis);
     }
 
-    public static String saveBitmapExternally(Bitmap bitmap) throws FileNotFoundException {
-        File pictureFile = getOutputMediaFile(MEDIA_TYPE_IMAGE);
+    public static String saveBitmapExternally(Bitmap bitmap, File pictureFile) throws FileNotFoundException {
         FileOutputStream out = null;
 
         try {
@@ -123,47 +122,8 @@ public class StorageAccessor {
         }
     }
 
-    public static String saveBitmapInternally(Bitmap bitmap, Context context) throws FileNotFoundException {
-        FileOutputStream fos = null;
-        try {
-            fos = context.openFileOutput(TEMPORARY_IMAGE_FILENAME, Context.MODE_PRIVATE);
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, fos);
-            return TEMPORARY_IMAGE_FILENAME;
-        } finally {
-            try {
-                if (fos != null) {
-                    fos.close();
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
-    public static void deleteInternalBitmap(Context context) {
-        context.deleteFile(TEMPORARY_IMAGE_FILENAME);
-    }
-
-    public static Bitmap readInternalBitmap(Context context) throws IOException{
-        FileInputStream fis = null;
-        try {
-            fis = context.openFileInput(TEMPORARY_IMAGE_FILENAME);
-            byte arr[] = new byte[(int) fis.getChannel().size()];
-            fis.read(arr);
-            return BitmapFactory.decodeByteArray(arr, 0, arr.length);
-        } finally {
-            try {
-                if (fis != null) {
-                    fis.close();
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
     /** Create a File for saving an image or video */
-    private static File getOutputMediaFile(int type){
+    public static File getOutputMediaFile(int type){
         // To be safe, you should check that the SDCard is mounted
         // using Environment.getExternalStorageState() before doing this.
 

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/Model/Submission.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/Model/Submission.java
@@ -1,5 +1,6 @@
 package com.blueprint.foe.beetracker.Model;
 
+import android.graphics.Bitmap;
 import android.location.Location;
 import android.util.Log;
 
@@ -23,6 +24,7 @@ public class Submission {
     private Weather mWeather = null;
     private Place mPlace = null;
     private String mImageFilePath = null;
+    private transient Bitmap mBitmap = null;
 
     @Override
     public boolean equals(Object other) {
@@ -40,6 +42,7 @@ public class Submission {
                 && this.mHabitat == that.mHabitat
                 && this.mWeather == that.mWeather
                 && this.mImageFilePath == that.mImageFilePath
+                && this.mBitmap.equals(that.mBitmap)
                 && ((this.mPlace == null && that.mPlace == null) || this.mPlace.equals(that.mPlace));
     }
 
@@ -211,6 +214,15 @@ public class Submission {
 
     public void setImageFilePath(String imageFilePath) {
         mImageFilePath = imageFilePath;
+    }
+
+    public Bitmap getBitmap() {
+        // if mBitmap is null, load it from image file path?
+        return mBitmap;
+    }
+
+    public void setBitmap(Bitmap bitmap) {
+        mBitmap = bitmap;
     }
 
     public boolean isComplete() {

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/Model/Submission.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/Model/Submission.java
@@ -110,6 +110,7 @@ public class Submission {
         mWeather = null;
         mPlace = null;
         mImageFilePath = null;
+        mBitmap = null;
     }
 
     public Submission() {
@@ -217,7 +218,7 @@ public class Submission {
     }
 
     public Bitmap getBitmap() {
-        // if mBitmap is null, load it from image file path?
+
         return mBitmap;
     }
 

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/Model/Submission.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/Model/Submission.java
@@ -42,8 +42,10 @@ public class Submission {
                 && this.mHabitat == that.mHabitat
                 && this.mWeather == that.mWeather
                 && this.mImageFilePath == that.mImageFilePath
-                && this.mBitmap.equals(that.mBitmap)
-                && ((this.mPlace == null && that.mPlace == null) || this.mPlace.equals(that.mPlace));
+                && ((this.mBitmap == null && that.mBitmap == null)
+                    || this.mBitmap != null && that.mBitmap != null && this.mBitmap.equals(that.mBitmap))
+                && ((this.mPlace == null && that.mPlace == null)
+                    || this.mPlace != null && that.mPlace != null && this.mPlace.equals(that.mPlace));
     }
 
     public enum Species {
@@ -218,7 +220,6 @@ public class Submission {
     }
 
     public Bitmap getBitmap() {
-
         return mBitmap;
     }
 

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/ReviewFragment.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/ReviewFragment.java
@@ -74,7 +74,7 @@ public class ReviewFragment extends Fragment implements BeeAlertDialogListener {
 
         // Set up image preview in top left corner
         final Submission submission = ((SubmissionActivity) getActivity()).getSubmission();
-        Bitmap bitmap = BitmapFactory.decodeFile(submission.getImageFilePath());
+        Bitmap bitmap = submission.getBitmap();
         int width = bitmap.getWidth();
         Bitmap scaled = Bitmap.createScaledBitmap(bitmap, container.getWidth(), (int)(((double)bitmap.getHeight() / (double)width) * container.getWidth()), false);
         ImageView preview = (ImageView) view.findViewById(R.id.beeImageView);

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/SubmissionActivity.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/SubmissionActivity.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 
 public class SubmissionActivity extends AppCompatActivity implements SubmissionInterface {
     public static final int MY_PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 1;
+
     private static final String TAG = SubmissionActivity.class.toString();
     private Submission submission;
 

--- a/BeeTracker/app/src/test/java/com/blueprint/foe/beetracker/Model/StorageAccessorTest.java
+++ b/BeeTracker/app/src/test/java/com/blueprint/foe/beetracker/Model/StorageAccessorTest.java
@@ -123,12 +123,4 @@ public class StorageAccessorTest {
         FactCollection facts = StorageAccessor.loadFacts(fis);
         assertTrue(correctFacts.equals(facts));
     }
-
-    @Test
-    public void saveBitmapInternally_isCorrect() throws Exception {
-        when(context.openFileOutput("TemporaryImageFile", Context.MODE_PRIVATE)).thenReturn(fos);
-        String result = StorageAccessor.saveBitmapInternally(bitmap, context);
-        verify(bitmap, times(1)).compress(Bitmap.CompressFormat.JPEG, 100, fos);
-        assertEquals("TemporaryImageFile", result);
-    }
 }


### PR DESCRIPTION
There was a lot of code before to save a bitmap internally while the app didn't have permission to save externally, but it wasn't really necessary. I changed the code to store the rendered Bitmap directly in the submission model, in that way we are not converting between stored images and bitmap's. I pushed the permissions check up into fragment load. I pushed the saving to external storage into a separate thread. The process produced a 2x speedup (4 seconds to 2 seconds from image capture to next fragment loaded).