### PR TITLE
Disable dismiss

### DIFF
--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/API/BeeTrackerCaller.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/API/BeeTrackerCaller.java
@@ -220,7 +220,6 @@ public class BeeTrackerCaller {
         Retrofit retrofit = new Retrofit.Builder()
                 .baseUrl(API_URL)
                 .addConverterFactory(GsonConverterFactory.create())
-                .client(getOkHttpClient())
                 .build();
 
         BeeTrackerService service = retrofit.create(BeeTrackerService.class);
@@ -231,7 +230,6 @@ public class BeeTrackerCaller {
         Retrofit retrofit = new Retrofit.Builder()
                 .baseUrl(API_URL)
                 .addConverterFactory(GsonConverterFactory.create())
-                .client(getOkHttpClient())
                 .build();
 
         BeeTrackerService service = retrofit.create(BeeTrackerService.class);
@@ -242,7 +240,6 @@ public class BeeTrackerCaller {
         Retrofit retrofit = new Retrofit.Builder()
                 .baseUrl(API_URL)
                 .addConverterFactory(GsonConverterFactory.create())
-                .client(getOkHttpClient())
                 .build();
 
         BeeTrackerService service = retrofit.create(BeeTrackerService.class);

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/API/BeeTrackerCaller.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/API/BeeTrackerCaller.java
@@ -14,6 +14,7 @@ import com.google.gson.annotations.SerializedName;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import okhttp3.CipherSuite;
 import okhttp3.ConnectionSpec;
@@ -71,7 +72,33 @@ public class BeeTrackerCaller {
     }
 
     public class LogInResponse {
-        // Only the response headers matter for sign in
+        @SerializedName("success")
+        boolean success;
+
+        @SerializedName("errors")
+        List<String> errors;
+
+        public String getConfirmationError() {
+            for (String error: errors) {
+                if (error.toLowerCase().contains("confirmation email")) {
+                    return error;
+                }
+            }
+            return null;
+        }
+    }
+
+    public class ResendEmailRequest {
+        @SerializedName("email")
+        String email;
+
+        public ResendEmailRequest(String email) {
+            this.email = email;
+        }
+    }
+
+    public class ResendEmailResponse {
+        // Don't need anything from the response
     }
 
     public class Image {
@@ -115,7 +142,11 @@ public class BeeTrackerCaller {
             this.longitude = submission.getLocation().getLatLng().longitude;
             this.street_address = submission.getLocation().getName().toString();
             this.weather = submission.getWeather().name().toLowerCase();
-            this.habitat = submission.getHabitat().name().toLowerCase();
+            if (submission.getHabitat() == Submission.Habitat.Balcony_Container_Garden) {
+                this.habitat = "balcony/container_garden";
+            } else {
+                this.habitat = submission.getHabitat().name().toLowerCase();
+            }
             this.species = null;
             if (submission.getSpecies() != null) {
                 this.species = "bombus_" + submission.getSpecies().toString().toLowerCase();
@@ -205,6 +236,17 @@ public class BeeTrackerCaller {
 
         BeeTrackerService service = retrofit.create(BeeTrackerService.class);
         return service.logIn(new LogInRequest(email, password));
+    }
+
+    public Call<ResendEmailResponse> resendEmail(String email) throws IOException {
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(API_URL)
+                .addConverterFactory(GsonConverterFactory.create())
+                .client(getOkHttpClient())
+                .build();
+
+        BeeTrackerService service = retrofit.create(BeeTrackerService.class);
+        return service.resendEmail(new ResendEmailRequest(email));
     }
 
     public Call<SubmissionResponse> submit(Submission submission, String accessToken, String tokenType, String client, String uid) throws IOException{

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/API/BeeTrackerService.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/API/BeeTrackerService.java
@@ -21,6 +21,10 @@ public interface  BeeTrackerService {
     Call<BeeTrackerCaller.LogInResponse> logIn(@Body BeeTrackerCaller.LogInRequest signinRequest);
 
     @Headers("Content-Type: application/json")
+    @POST("/auth/resend_confirmation")
+    Call<BeeTrackerCaller.ResendEmailResponse> resendEmail(@Body BeeTrackerCaller.ResendEmailRequest resendRequest);
+
+    @Headers("Content-Type: application/json")
     @POST("/sightings")
     Call<BeeTrackerCaller.SubmissionResponse> submitSighting(@Header("access-token") String accessToken, @Header("token-type") String tokenType, @Header("client") String client, @Header("uid") String uid, @Body BeeTrackerCaller.SubmissionRequest submissionRequest);
 }

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/ConfirmEmailFragment.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/ConfirmEmailFragment.java
@@ -5,14 +5,26 @@ import android.app.FragmentManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.TextView;
+import android.widget.Toast;
+
+import com.blueprint.foe.beetracker.API.BeeTrackerCaller;
+
+import java.io.IOException;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class ConfirmEmailFragment extends Fragment {
     private static final String TAG = SignUpFragment.class.toString();
+    private Callback resendCallback;
+    private SpinningIconDialog spinningIconDialog;
 
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
@@ -20,9 +32,11 @@ public class ConfirmEmailFragment extends Fragment {
 
         TextView almostThere = (TextView) view.findViewById(R.id.almostThereText);
         TextView confirmEmailDescription = (TextView) view.findViewById(R.id.confirmEmailDescription);
+        TextView resendEmail = (TextView) view.findViewById(R.id.resendEmail);
+        TextView backToLogin = (TextView) view.findViewById(R.id.backToLogin);
 
         SharedPreferences sharedPref = getActivity().getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
-        String email = sharedPref.getString(getString(R.string.signup_email), null);
+        final String email = sharedPref.getString(getString(R.string.signup_email), null);
         String fullName = sharedPref.getString(getString(R.string.signup_name), null);
 
         if (fullName != null && !fullName.isEmpty()) {
@@ -33,12 +47,58 @@ public class ConfirmEmailFragment extends Fragment {
             confirmEmailDescription.setText(getString(R.string.confirm_email_description, email));
         }
 
-        sharedPref.edit().remove(getString(R.string.signup_name)).commit();
-        sharedPref.edit().remove(getString(R.string.signup_email)).commit();
-        sharedPref.edit().remove(getString(R.string.signup_password)).commit();
-
         ImageButton cancelButton = (ImageButton) view.findViewById(R.id.cancelButton);
         cancelButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // Back to main activity
+                getFragmentManager().popBackStack("main", FragmentManager.POP_BACK_STACK_INCLUSIVE);
+            }
+        });
+
+        resendCallback = new Callback<BeeTrackerCaller.ResendEmailResponse>() {
+            @Override
+            public void onResponse(Call<BeeTrackerCaller.ResendEmailResponse> call, Response<BeeTrackerCaller.ResendEmailResponse> response) {
+                if (response.code() == 401 || response.body() == null) {
+                    Log.e(TAG, "The response from the server is 401 + " + response.message());
+                    showErrorDialog(getString(R.string.error_message_resend_email));
+                    return;
+                }
+
+                if (spinningIconDialog != null) {
+                    spinningIconDialog.dismiss();
+                }
+
+                Toast.makeText(getActivity(), getString(R.string.confirm_email_resent, email), Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onFailure(Call<BeeTrackerCaller.ResendEmailResponse> call, Throwable t) {
+                Log.e(TAG, "There was an error with the signup callback + " + t.toString());
+                t.printStackTrace();
+                showErrorDialog(getString(R.string.error_message_resend_email));
+            }
+        };
+
+        resendEmail.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                spinningIconDialog = new SpinningIconDialog();
+                spinningIconDialog.show(getFragmentManager(), "SpinningPopup");
+
+                BeeTrackerCaller caller = new BeeTrackerCaller();
+                try {
+                    Call<BeeTrackerCaller.ResendEmailResponse> call = caller.resendEmail(email);
+                    call.enqueue(resendCallback);
+                } catch (IOException e) {
+                    Log.e(TAG, e.toString());
+                    e.printStackTrace();
+                    showErrorDialog(getString(R.string.error_message_signup));
+                }
+            }
+        });
+
+        backToLogin.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 // Back to main activity
@@ -49,4 +109,14 @@ public class ConfirmEmailFragment extends Fragment {
         return view;
     }
 
+    private void showErrorDialog(String message) {
+        if (spinningIconDialog != null) {
+            spinningIconDialog.dismiss();
+        }
+        BeeAlertErrorDialog dialog = new BeeAlertErrorDialog();
+        Bundle args = new Bundle();
+        args.putString(BeeAlertErrorDialog.ERROR_MESSAGE_KEY, message);
+        dialog.setArguments(args);
+        dialog.show(getFragmentManager(), "ErrorMessage");
+    }
 }

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/MainActivity.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/MainActivity.java
@@ -16,10 +16,12 @@ import android.widget.TextView;
 
 import com.blueprint.foe.beetracker.API.BeeTrackerCaller;
 import com.blueprint.foe.beetracker.Listeners.BeeAlertDialogListener;
+import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.util.ArrayList;
 
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -65,6 +67,18 @@ public class MainActivity extends AppCompatActivity implements BeeAlertDialogLis
             }
         });
 
+        SharedPreferences sharedPref = getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
+        String email = sharedPref.getString(getString(R.string.signup_email), null);
+        String password = sharedPref.getString(getString(R.string.signup_password), null);
+
+        if (email != null) {
+            mEmailInput.setText(email);
+        }
+        if (password != null) {
+            mPasswordInput.setText(password);
+        }
+
+
         Button emailLoginButton = (Button) findViewById(R.id.email_login_button);
         emailLoginButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -74,8 +88,8 @@ public class MainActivity extends AppCompatActivity implements BeeAlertDialogLis
 
                 BeeTrackerCaller caller = new BeeTrackerCaller();
                 try {
-                    String email = ((EditText) findViewById(R.id.email_input)).getText().toString();
-                    String password = ((EditText) findViewById(R.id.password_input)).getText().toString();
+                    String email = mEmailInput.getText().toString();
+                    String password = mPasswordInput.getText().toString();
 
                     if (!loginFieldsAreValid(email, password)) {
                         return;
@@ -96,8 +110,17 @@ public class MainActivity extends AppCompatActivity implements BeeAlertDialogLis
             public void onResponse(Call<BeeTrackerCaller.LogInResponse> call, Response<BeeTrackerCaller.LogInResponse> response) {
                 if (response.code() == 401 || response.headers() == null) {
                     Log.e(TAG, "The response from the server is 401 + " + response.message());
+                    if (response.errorBody() != null) {
+                        Gson gson = new Gson();
+                        BeeTrackerCaller.LogInResponse message = gson.fromJson(response.errorBody().charStream(),BeeTrackerCaller.LogInResponse.class);
+                        if (message != null && message.getConfirmationError() != null) {
+                            showErrorDialog(message.getConfirmationError());
+                            return;
+                        }
+                    }
                     showErrorDialog(getString(R.string.error_message_login));
                     setAllLabelsAndFieldsToError();
+
                     return;
                 }
                 SharedPreferences sharedPref = getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
@@ -122,8 +145,8 @@ public class MainActivity extends AppCompatActivity implements BeeAlertDialogLis
         signUpButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                String email = ((EditText) findViewById(R.id.email_input)).getText().toString();
-                String password = ((EditText) findViewById(R.id.password_input)).getText().toString();
+                String email = mEmailInput.getText().toString();
+                String password = mPasswordInput.getText().toString();
 
                 SharedPreferences sharedPref = getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
                 sharedPref.edit().putString(getString(R.string.signup_email), email).commit();
@@ -222,4 +245,14 @@ public class MainActivity extends AppCompatActivity implements BeeAlertDialogLis
 
     @Override
     public void onDialogFinishClick(int id) {}
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        SharedPreferences sharedPref = getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
+
+        sharedPref.edit().remove(getString(R.string.signup_name)).commit();
+        sharedPref.edit().remove(getString(R.string.signup_email)).commit();
+        sharedPref.edit().remove(getString(R.string.signup_password)).commit();
+    }
 }

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/MainActivity.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/MainActivity.java
@@ -129,6 +129,10 @@ public class MainActivity extends AppCompatActivity implements BeeAlertDialogLis
                 sharedPref.edit().putString(getString(R.string.preference_login_client), response.headers().get("client")).commit();
                 sharedPref.edit().putString(getString(R.string.preference_login_expiry), response.headers().get("expiry")).commit();
                 sharedPref.edit().putString(getString(R.string.preference_login_uid), response.headers().get("uid")).commit();
+
+                sharedPref.edit().remove(getString(R.string.signup_name)).commit();
+                sharedPref.edit().remove(getString(R.string.signup_email)).commit();
+                sharedPref.edit().remove(getString(R.string.signup_password)).commit();
                 navigateToHome();
             }
 
@@ -245,14 +249,4 @@ public class MainActivity extends AppCompatActivity implements BeeAlertDialogLis
 
     @Override
     public void onDialogFinishClick(int id) {}
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        SharedPreferences sharedPref = getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
-
-        sharedPref.edit().remove(getString(R.string.signup_name)).commit();
-        sharedPref.edit().remove(getString(R.string.signup_email)).commit();
-        sharedPref.edit().remove(getString(R.string.signup_password)).commit();
-    }
 }

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/Model/Submission.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/Model/Submission.java
@@ -52,7 +52,7 @@ public class Submission {
 
 
     public enum Habitat {
-        Default, Back_Yard, Community_Garden, City_Park, Rural, Golf_Course, Roadside, Woodland, Farmland, School_Grounds, Other;
+        Default, Back_Yard, Balcony_Container_Garden, Community_Garden, City_Park, Rural, Golf_Course, Roadside, Woodland, Farmland, School_Grounds, Other;
 
         @Override
         public String toString() {
@@ -61,6 +61,8 @@ public class Submission {
                     return "";
                 case Back_Yard:
                     return "Back Yard";
+                case Balcony_Container_Garden:
+                    return "Balcony/Container Garden";
                 case Community_Garden:
                     return "Community Garden";
                 case City_Park:

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/ReviewFragment.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/ReviewFragment.java
@@ -199,6 +199,7 @@ public class ReviewFragment extends Fragment implements BeeAlertDialogListener {
         args.putString(BeeAlertDialog.HEADING, getString(R.string.submit_dialog_heading));
         args.putString(BeeAlertDialog.PARAGRAPH, getString(R.string.submit_dialog_paragraph));
         dialog.setArguments(args);
+        dialog.setCancelable(false);
         dialog.show(getActivity().getFragmentManager(), "SubmissionPopup");
     }
 

--- a/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/SignUpFragment.java
+++ b/BeeTracker/app/src/main/java/com/blueprint/foe/beetracker/SignUpFragment.java
@@ -45,14 +45,14 @@ public class SignUpFragment extends Fragment {
         final View view = inflater.inflate(R.layout.sign_up_fragment, container, false);
         mErrorMessage = (TextView) view.findViewById(R.id.error_message);
 
-        mNameLabel = (TextView) view.findViewById(R.id.name_label);
-        mEmailLabel = (TextView) view.findViewById(R.id.email_label);
-        mPasswordLabel = (TextView) view.findViewById(R.id.password_label);
-        mConfirmPasswordLabel = (TextView) view.findViewById(R.id.confirm_password_label);
-        mNameInput = (EditText) view.findViewById(R.id.name_input);
-        mEmailInput = (EditText) view.findViewById(R.id.email_input);
-        mPasswordInput = (EditText) view.findViewById(R.id.password_input);
-        mConfirmPasswordInput = (EditText) view.findViewById(R.id.confirm_password_input);
+        mNameLabel = (TextView) view.findViewById(R.id.sign_up_name_label);
+        mEmailLabel = (TextView) view.findViewById(R.id.sign_up_email_label);
+        mPasswordLabel = (TextView) view.findViewById(R.id.sign_up_password_label);
+        mConfirmPasswordLabel = (TextView) view.findViewById(R.id.sign_up_confirm_password_label);
+        mNameInput = (EditText) view.findViewById(R.id.sign_up_name_input);
+        mEmailInput = (EditText) view.findViewById(R.id.sign_up_email_input);
+        mPasswordInput = (EditText) view.findViewById(R.id.sign_up_password_input);
+        mConfirmPasswordInput = (EditText) view.findViewById(R.id.sign_up_confirm_password_input);
 
         SharedPreferences sharedPref = getActivity().getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
         String signupEmail = sharedPref.getString(getString(R.string.signup_email), null);
@@ -128,10 +128,10 @@ public class SignUpFragment extends Fragment {
 
                 BeeTrackerCaller caller = new BeeTrackerCaller();
                 try {
-                    String name = ((EditText) view.findViewById(R.id.name_input)).getText().toString();
-                    String email = ((EditText) view.findViewById(R.id.email_input)).getText().toString();
-                    String password = ((EditText) view.findViewById(R.id.password_input)).getText().toString();
-                    String confirmPassword = ((EditText) view.findViewById(R.id.confirm_password_input)).getText().toString();
+                    String name = ((EditText) view.findViewById(R.id.sign_up_name_input)).getText().toString();
+                    String email = ((EditText) view.findViewById(R.id.sign_up_email_input)).getText().toString();
+                    String password = ((EditText) view.findViewById(R.id.sign_up_password_input)).getText().toString();
+                    String confirmPassword = ((EditText) view.findViewById(R.id.sign_up_confirm_password_input)).getText().toString();
 
                     if (!signupFieldsAreValid(name, email, password, confirmPassword)) {
                         return;
@@ -212,16 +212,16 @@ public class SignUpFragment extends Fragment {
 
             EditText inputFieldToSet;
             switch (label.getLabelFor()) {
-                case R.id.name_input:
+                case R.id.sign_up_name_input:
                     inputFieldToSet = mNameInput;
                     break;
-                case R.id.email_input:
+                case R.id.sign_up_email_input:
                     inputFieldToSet = mEmailInput;
                     break;
-                case R.id.password_input:
+                case R.id.sign_up_password_input:
                     inputFieldToSet = mPasswordInput;
                     break;
-                case R.id.confirm_password_input:
+                case R.id.sign_up_confirm_password_input:
                     inputFieldToSet = mConfirmPasswordInput;
                     break;
                 default:

--- a/BeeTracker/app/src/main/res/layout/activity_main.xml
+++ b/BeeTracker/app/src/main/res/layout/activity_main.xml
@@ -118,6 +118,7 @@
             android:textColorHint="@color/lightGrey"
             android:inputType="textEmailAddress"
             android:textColor="@color/black"
+            android:nextFocusDown="@+id/password_input"
             android:textSize="@dimen/login_signup_input_text_size" />
 
         <TextView
@@ -133,7 +134,7 @@
             android:textSize="@dimen/login_signup_label_text_size" />
 
         <EditText
-            android:id="@+id/password_input"
+            android:id="@id/password_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"

--- a/BeeTracker/app/src/main/res/layout/confirm_email_fragment.xml
+++ b/BeeTracker/app/src/main/res/layout/confirm_email_fragment.xml
@@ -102,6 +102,17 @@
             android:textColor="@color/grassGreen"
             android:textSize="@dimen/medium_text_size" />
 
+        <TextView
+            android:id="@+id/backToLogin"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/resendEmail"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="@dimen/big_padding"
+            android:text="@string/back_to_signin"
+            android:textColor="@color/grassGreen"
+            android:textSize="@dimen/medium_text_size" />
+
     </RelativeLayout>
 
 

--- a/BeeTracker/app/src/main/res/layout/sign_up_fragment.xml
+++ b/BeeTracker/app/src/main/res/layout/sign_up_fragment.xml
@@ -79,21 +79,21 @@
         app:layout_constraintTop_toBottomOf="@+id/inputFieldsTopGuideline">
 
         <TextView
-            android:id="@+id/name_label"
+            android:id="@+id/sign_up_name_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
-            android:labelFor="@+id/name_input"
+            android:labelFor="@+id/sign_up_name_input"
             android:text="@string/name_label"
             android:textColor="@color/subheadingTextColour"
             android:textSize="@dimen/login_signup_label_text_size" />
 
         <EditText
-            android:id="@+id/name_input"
+            android:id="@+id/sign_up_name_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
-            android:layout_below="@id/name_label"
+            android:layout_below="@id/sign_up_name_label"
             android:layout_marginLeft="@dimen/login_signup_input_padding_adjustment"
             android:layout_marginRight="@dimen/login_signup_input_padding_adjustment"
             android:layout_marginTop="@dimen/small_padding"
@@ -102,26 +102,27 @@
             android:textColor="@color/black"
             android:textColorHint="@color/lightGrey"
             android:textSize="@dimen/login_signup_input_text_size"
+            android:nextFocusDown="@+id/sign_up_email_input"
             android:theme="@style/LoginSignupEditTextTheme" />
 
         <TextView
-            android:id="@+id/email_label"
+            android:id="@+id/sign_up_email_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
-            android:layout_below="@id/name_input"
+            android:layout_below="@id/sign_up_name_input"
             android:layout_marginTop="@dimen/medium_small_padding"
-            android:labelFor="@+id/email_input"
+            android:labelFor="@+id/sign_up_email_input"
             android:text="@string/email_label"
             android:textColor="@color/subheadingTextColour"
             android:textSize="@dimen/login_signup_label_text_size" />
 
         <EditText
-            android:id="@+id/email_input"
+            android:id="@id/sign_up_email_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
-            android:layout_below="@id/email_label"
+            android:layout_below="@id/sign_up_email_label"
             android:layout_marginLeft="@dimen/login_signup_input_padding_adjustment"
             android:layout_marginRight="@dimen/login_signup_input_padding_adjustment"
             android:layout_marginTop="@dimen/small_padding"
@@ -130,26 +131,27 @@
             android:textColor="@color/black"
             android:textColorHint="@color/lightGrey"
             android:textSize="@dimen/login_signup_input_text_size"
+            android:nextFocusDown="@+id/sign_up_password_input"
             android:theme="@style/LoginSignupEditTextTheme" />
 
         <TextView
-            android:id="@+id/password_label"
+            android:id="@+id/sign_up_password_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
-            android:layout_below="@id/email_input"
+            android:layout_below="@id/sign_up_email_input"
             android:layout_marginTop="@dimen/medium_small_padding"
-            android:labelFor="@+id/password_input"
+            android:labelFor="@+id/sign_up_password_input"
             android:text="@string/password_label"
             android:textColor="@color/subheadingTextColour"
             android:textSize="@dimen/login_signup_label_text_size" />
 
         <EditText
-            android:id="@+id/password_input"
+            android:id="@id/sign_up_password_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
-            android:layout_below="@id/password_label"
+            android:layout_below="@id/sign_up_password_label"
             android:layout_marginLeft="@dimen/login_signup_input_padding_adjustment"
             android:layout_marginRight="@dimen/login_signup_input_padding_adjustment"
             android:layout_marginTop="@dimen/small_padding"
@@ -158,26 +160,27 @@
             android:textColor="@color/black"
             android:textColorHint="@color/lightGrey"
             android:textSize="@dimen/login_signup_input_text_size"
+            android:nextFocusDown="@+id/sign_up_confirm_password_input"
             android:theme="@style/LoginSignupEditTextTheme" />
 
         <TextView
-            android:id="@+id/confirm_password_label"
+            android:id="@+id/sign_up_confirm_password_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
-            android:layout_below="@id/password_input"
+            android:layout_below="@id/sign_up_password_input"
             android:layout_marginTop="@dimen/medium_small_padding"
-            android:labelFor="@+id/confirm_password_input"
+            android:labelFor="@+id/sign_up_confirm_password_input"
             android:text="@string/confirm_password_label"
             android:textColor="@color/subheadingTextColour"
             android:textSize="@dimen/login_signup_label_text_size" />
 
         <EditText
-            android:id="@+id/confirm_password_input"
+            android:id="@id/sign_up_confirm_password_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
-            android:layout_below="@id/confirm_password_label"
+            android:layout_below="@id/sign_up_confirm_password_label"
             android:layout_marginLeft="@dimen/login_signup_input_padding_adjustment"
             android:layout_marginRight="@dimen/login_signup_input_padding_adjustment"
             android:layout_marginTop="@dimen/small_padding"

--- a/BeeTracker/app/src/main/res/layout/weather_option.xml
+++ b/BeeTracker/app/src/main/res/layout/weather_option.xml
@@ -16,5 +16,6 @@
         android:textColor="@color/black"
         android:textStyle="italic"
         android:textAlignment="center"
+        android:gravity="center"
         android:id="@+id/weatherType"/>
 </LinearLayout>

--- a/BeeTracker/app/src/main/res/values/strings.xml
+++ b/BeeTracker/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="error_message_signup">Something went wrong with your sign-up, please try again.</string>
     <string name="error_message_password_mismatch">Passwords do not match.</string>
     <string name="error_message_password_too_short">Passwords must be at least 8 characters long.</string>
+    <string name="error_message_resend_email">Something went wrong with resending your confirmation email, please try again.</string>
     <string name="error_message_submit">Something went wrong with submitting your image.</string>
     <string name="preference_file_key">com.blueprint.foe.beetracker.PREFERENCE_FILE_KEY</string>
     <string name="preference_login_token">LOGIN_TOKEN</string>
@@ -66,6 +67,8 @@
     <string name="almost_there">Almost there, %1$s!</string>
     <string name="confirm_email_description">We\'ve sent an email to <b>%1$s</b> with a confirmation link to complete your signup.</string>
     <string name="resend_email">Resend Email</string>
+    <string name="confirm_email_resent">We\'ve sent another email to <b>%1$s</b>.</string>
+    <string name="back_to_signin">Return to login</string>
     <string name="forgot_password">Forgot Password?</string>
     <string name="login">Log In</string>
     <string name="signup">Sign Up</string>


### PR DESCRIPTION
Fixes:
- Added resend email functionality
- Parse login error response to determine if they're waiting on a confirmation email to login
- Added balcony/container garden as a habitat
- Removed response logs
- Disabled the buzz buzz modal from exiting other than through the "Finish" button. Otherwise users would have no way of getting back to the home screen.
- Fixed bug where weather picker options weren't centered
- Fixed bug where tapping next on the signup modal wasn't taking you to the correct EditText